### PR TITLE
fix: remove indexed string for path name from RevenuePathCreated event

### DIFF
--- a/contracts/core/ReveelMain.sol
+++ b/contracts/core/ReveelMain.sol
@@ -22,7 +22,7 @@ contract ReveelMain is Ownable, Pausable {
     /** @notice Emits when a new revenue path is created
      * @param path The address of the new revenue path
      */
-    event RevenuePathCreated(RevenuePath indexed path, string indexed name);
+    event RevenuePathCreated(RevenuePath indexed path, string name);
     /** @notice Updates the libaray contract address
      * @param newLibrary The address of the library contract
      */

--- a/deploy/1_ReveelMain_deploy.js
+++ b/deploy/1_ReveelMain_deploy.js
@@ -2,7 +2,7 @@ const hre = require("hardhat");
 
 async function main() {
 
-  const libraryAddress = "0x3b612700A50a62C9807B0a5a451E0b248c853897";
+  const libraryAddress = "0x7Ff51f4018DedB5632c2d5b103cA81BcA08bD0af";
   const feePercentage = 100; //1%
   const platformWallet = "0xcAa029e5ba2b233ce50467cf01Fc727b45925A23";
 


### PR DESCRIPTION
- indexing the name in the RevenuePathCreated event makes the name not parseable in event logs. (we currently need to parse that event name to work smoothly in conjunction with v0 frontend logic)
- background is per: https://ethereum.stackexchange.com/questions/6840/indexed-event-with-string-not-getting-logged/7170#7170
- other options are listed in that answer
- IMO we don't need indexing on the name since we won't filter events with it